### PR TITLE
Add support for PlaceholderAPI

### DIFF
--- a/src/main/java/de/czymm/serversigns/hooks/HookManager.java
+++ b/src/main/java/de/czymm/serversigns/hooks/HookManager.java
@@ -24,11 +24,14 @@ public class HookManager {
     public final HookWrapper<EssentialsHook> essentials;
     public final HookWrapper<NoCheatPlusHook> noCheatPlus;
     public final HookWrapper<VaultHook> vault;
+    public final HookWrapper<PlaceholderAPIHook> placeholderApi;
+
 
     public HookManager(ServerSignsPlugin plugin) {
         essentials = new HookWrapper<>(EssentialsHook.class, new Class[]{ServerSignsPlugin.class}, new Object[]{plugin});
         noCheatPlus = new HookWrapper<>(NoCheatPlusHook.class, new Class[]{ServerSignsPlugin.class}, new Object[]{plugin});
         vault = new HookWrapper<>(VaultHook.class, new Class[]{ServerSignsPlugin.class}, new Object[]{plugin});
+        placeholderApi = new HookWrapper<>(PlaceholderAPIHook.class, new Class[]{ServerSignsPlugin.class}, new Object[]{plugin});
     }
 
     public void tryInstantiateHooks(boolean deepVerbose) {
@@ -47,6 +50,11 @@ public class HookManager {
         } catch (Exception ex) {
             ServerSignsPlugin.log("Unable to load Vault dependency - certain economy and permission features will be disabled");
             ServerSignsPlugin.log("Please download Vault at http://dev.bukkit.org/server-mods/vault/ for Economy and \"Permission grant\" support.");
+        }
+        try {
+            placeholderApi.instantiateHook();
+        } catch (Exception ex) {
+            ServerSignsPlugin.log("Unable to load PlaceholderAPI dependency - placeholder features will be disabled");
         }
     }
 }

--- a/src/main/java/de/czymm/serversigns/hooks/HookManager.java
+++ b/src/main/java/de/czymm/serversigns/hooks/HookManager.java
@@ -26,7 +26,6 @@ public class HookManager {
     public final HookWrapper<VaultHook> vault;
     public final HookWrapper<PlaceholderAPIHook> placeholderAPI;
 
-
     public HookManager(ServerSignsPlugin plugin) {
         essentials = new HookWrapper<>(EssentialsHook.class, new Class[]{ServerSignsPlugin.class}, new Object[]{plugin});
         noCheatPlus = new HookWrapper<>(NoCheatPlusHook.class, new Class[]{ServerSignsPlugin.class}, new Object[]{plugin});
@@ -52,7 +51,7 @@ public class HookManager {
             ServerSignsPlugin.log("Please download Vault at http://dev.bukkit.org/server-mods/vault/ for Economy and \"Permission grant\" support.");
         }
         try {
-        	placeholderAPI.instantiateHook();
+            placeholderAPI.instantiateHook();
         } catch (Exception ex) {
             ServerSignsPlugin.log("Unable to load PlaceholderAPI dependency - placeholder features will be disabled");
         }

--- a/src/main/java/de/czymm/serversigns/hooks/HookManager.java
+++ b/src/main/java/de/czymm/serversigns/hooks/HookManager.java
@@ -24,14 +24,14 @@ public class HookManager {
     public final HookWrapper<EssentialsHook> essentials;
     public final HookWrapper<NoCheatPlusHook> noCheatPlus;
     public final HookWrapper<VaultHook> vault;
-    public final HookWrapper<PlaceholderAPIHook> placeholderApi;
+    public final HookWrapper<PlaceholderAPIHook> placeholderAPI;
 
 
     public HookManager(ServerSignsPlugin plugin) {
         essentials = new HookWrapper<>(EssentialsHook.class, new Class[]{ServerSignsPlugin.class}, new Object[]{plugin});
         noCheatPlus = new HookWrapper<>(NoCheatPlusHook.class, new Class[]{ServerSignsPlugin.class}, new Object[]{plugin});
         vault = new HookWrapper<>(VaultHook.class, new Class[]{ServerSignsPlugin.class}, new Object[]{plugin});
-        placeholderApi = new HookWrapper<>(PlaceholderAPIHook.class, new Class[]{ServerSignsPlugin.class}, new Object[]{plugin});
+        placeholderAPI = new HookWrapper<>(PlaceholderAPIHook.class, new Class[]{ServerSignsPlugin.class}, new Object[]{plugin});
     }
 
     public void tryInstantiateHooks(boolean deepVerbose) {
@@ -52,7 +52,7 @@ public class HookManager {
             ServerSignsPlugin.log("Please download Vault at http://dev.bukkit.org/server-mods/vault/ for Economy and \"Permission grant\" support.");
         }
         try {
-            placeholderApi.instantiateHook();
+        	placeholderAPI.instantiateHook();
         } catch (Exception ex) {
             ServerSignsPlugin.log("Unable to load PlaceholderAPI dependency - placeholder features will be disabled");
         }

--- a/src/main/java/de/czymm/serversigns/hooks/PlaceholderAPIHook.java
+++ b/src/main/java/de/czymm/serversigns/hooks/PlaceholderAPIHook.java
@@ -1,0 +1,37 @@
+/*
+ * This file is part of ServerSigns.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.czymm.serversigns.hooks;
+
+import de.czymm.serversigns.ServerSignsPlugin;
+import me.clip.placeholderapi.PlaceholderAPI;
+
+import org.bukkit.Bukkit;
+
+public class PlaceholderAPIHook {
+
+	protected ServerSignsPlugin pl;
+
+    private PlaceholderAPI placeholderAPI;
+
+    public PlaceholderAPIHook(ServerSignsPlugin plugin) throws Exception {
+        pl = plugin;
+        placeholderAPI = (PlaceholderAPI) Bukkit.getPluginManager().getPlugin("PlaceholderAPI");
+        if (placeholderAPI == null) throw new Exception();
+    }
+
+}

--- a/src/main/java/de/czymm/serversigns/hooks/PlaceholderAPIHook.java
+++ b/src/main/java/de/czymm/serversigns/hooks/PlaceholderAPIHook.java
@@ -18,7 +18,6 @@
 package de.czymm.serversigns.hooks;
 
 import de.czymm.serversigns.ServerSignsPlugin;
-import me.clip.placeholderapi.PlaceholderAPI;
 
 import org.bukkit.Bukkit;
 
@@ -26,12 +25,15 @@ public class PlaceholderAPIHook {
 
 	protected ServerSignsPlugin pl;
 
-    private PlaceholderAPI placeholderAPI;
-
     public PlaceholderAPIHook(ServerSignsPlugin plugin) throws Exception {
         pl = plugin;
-        placeholderAPI = (PlaceholderAPI) Bukkit.getPluginManager().getPlugin("PlaceholderAPI");
-        if (placeholderAPI == null) throw new Exception();
+        
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") == null) {
+        	throw new Exception();
+        }
+        
     }
+    
+
 
 }

--- a/src/main/java/de/czymm/serversigns/hooks/PlaceholderAPIHook.java
+++ b/src/main/java/de/czymm/serversigns/hooks/PlaceholderAPIHook.java
@@ -23,17 +23,15 @@ import org.bukkit.Bukkit;
 
 public class PlaceholderAPIHook {
 
-	protected ServerSignsPlugin pl;
+    protected ServerSignsPlugin pl;
 
     public PlaceholderAPIHook(ServerSignsPlugin plugin) throws Exception {
         pl = plugin;
-        
-        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") == null) {
-        	throw new Exception();
-        }
-        
-    }
-    
 
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") == null) {
+            throw new Exception();
+        }
+
+    }
 
 }

--- a/src/main/java/de/czymm/serversigns/parsing/operators/ConditionalOperator.java
+++ b/src/main/java/de/czymm/serversigns/parsing/operators/ConditionalOperator.java
@@ -40,7 +40,6 @@ public abstract class ConditionalOperator {
         VALUES.add(new NearbyPlayersOperator());
         VALUES.add(new OnlinePlayersOperator());
         VALUES.add(new HasBalanceOperator());
-        
         VALUES.add(new PlaceholderOperator());
     }
 

--- a/src/main/java/de/czymm/serversigns/parsing/operators/ConditionalOperator.java
+++ b/src/main/java/de/czymm/serversigns/parsing/operators/ConditionalOperator.java
@@ -40,6 +40,8 @@ public abstract class ConditionalOperator {
         VALUES.add(new NearbyPlayersOperator());
         VALUES.add(new OnlinePlayersOperator());
         VALUES.add(new HasBalanceOperator());
+        
+        VALUES.add(new PlaceholderOperator());
     }
 
     protected String key;

--- a/src/main/java/de/czymm/serversigns/parsing/operators/PlaceholderOperator.java
+++ b/src/main/java/de/czymm/serversigns/parsing/operators/PlaceholderOperator.java
@@ -14,22 +14,33 @@ public class PlaceholderOperator extends ConditionalOperator{
 
 	@Override
     public ParameterValidityResponse checkParameterValidity(String params) {
-        return new ParameterValidityResponse(true); // Params are irrelevant
+		boolean isValid = params.indexOf('=') > 0 && params.length() - 2 >= params.indexOf('=');
+        return new ParameterValidityResponse(isValid, "Parameter must be in the format <placeholder>=<match>");
     }
 
-    @Override
+	@Override
     public boolean meetsConditions(Player executor, ServerSign executingSign, ServerSignsPlugin plugin) {
-    	if (params == null) {
+    	if (params == null || params.indexOf('=') < 1) {
             return false;
         }
+    	
+    	if (!plugin.hookManager.placeholderAPI.isHooked()) {
+            return false;
+        }
+    	
         if (executor == null) {
             return true; // Console
         }
         
         String[] paramSplit = params.split("=");
+        String[] ors = paramSplit[1].split("\\|");
         
-        if(paramSplit.length < 2) {
-        	return false;
+        if(ors.length > 1) {
+        	for (String or : ors) {
+        		if (PlaceholderAPI.setPlaceholders(executor, paramSplit[0]).equals(or)) {
+                    return true;
+                }
+        	}
         }
 
         return PlaceholderAPI.setPlaceholders(executor, paramSplit[0]).equals(paramSplit[1]);

--- a/src/main/java/de/czymm/serversigns/parsing/operators/PlaceholderOperator.java
+++ b/src/main/java/de/czymm/serversigns/parsing/operators/PlaceholderOperator.java
@@ -6,44 +6,44 @@ import de.czymm.serversigns.ServerSignsPlugin;
 import de.czymm.serversigns.signs.ServerSign;
 import me.clip.placeholderapi.PlaceholderAPI;
 
-public class PlaceholderOperator extends ConditionalOperator{
+public class PlaceholderOperator extends ConditionalOperator {
 
-	public PlaceholderOperator() {
+    public PlaceholderOperator() {
         super("placeholder", true);
     }
 
-	@Override
+    @Override
     public ParameterValidityResponse checkParameterValidity(String params) {
-		boolean isValid = params.indexOf('=') > 0 && params.length() - 2 >= params.indexOf('=');
+        boolean isValid = params.indexOf('=') > 0 && params.length() - 2 >= params.indexOf('=');
         return new ParameterValidityResponse(isValid, "Parameter must be in the format <placeholder>=<match>");
     }
 
-	@Override
+    @Override
     public boolean meetsConditions(Player executor, ServerSign executingSign, ServerSignsPlugin plugin) {
-    	if (params == null || params.indexOf('=') < 1) {
+        if (params == null || params.indexOf('=') < 1) {
             return false;
         }
-    	
-    	if (!plugin.hookManager.placeholderAPI.isHooked()) {
+
+        if (!plugin.hookManager.placeholderAPI.isHooked()) {
             return false;
         }
-    	
+
         if (executor == null) {
             return true; // Console
         }
-        
+
         String[] paramSplit = params.split("=");
         String[] ors = paramSplit[1].split("\\|");
-        
-        if(ors.length > 1) {
-        	for (String or : ors) {
-        		if (PlaceholderAPI.setPlaceholders(executor, paramSplit[0]).equals(or)) {
+
+        if (ors.length > 1) {
+            for (String or : ors) {
+                if (PlaceholderAPI.setPlaceholders(executor, paramSplit[0]).equals(or)) {
                     return true;
                 }
-        	}
+            }
         }
 
         return PlaceholderAPI.setPlaceholders(executor, paramSplit[0]).equals(paramSplit[1]);
     }
-	
+
 }

--- a/src/main/java/de/czymm/serversigns/parsing/operators/PlaceholderOperator.java
+++ b/src/main/java/de/czymm/serversigns/parsing/operators/PlaceholderOperator.java
@@ -1,0 +1,38 @@
+package de.czymm.serversigns.parsing.operators;
+
+import org.bukkit.entity.Player;
+
+import de.czymm.serversigns.ServerSignsPlugin;
+import de.czymm.serversigns.signs.ServerSign;
+import me.clip.placeholderapi.PlaceholderAPI;
+
+public class PlaceholderOperator extends ConditionalOperator{
+
+	public PlaceholderOperator() {
+        super("placeholder", true);
+    }
+
+	@Override
+    public ParameterValidityResponse checkParameterValidity(String params) {
+        return new ParameterValidityResponse(true); // Params are irrelevant
+    }
+
+    @Override
+    public boolean meetsConditions(Player executor, ServerSign executingSign, ServerSignsPlugin plugin) {
+    	if (params == null) {
+            return false;
+        }
+        if (executor == null) {
+            return true; // Console
+        }
+        
+        String[] paramSplit = params.split("=");
+        
+        if(paramSplit.length < 2) {
+        	return false;
+        }
+
+        return PlaceholderAPI.setPlaceholders(executor, paramSplit[0]).equals(paramSplit[1]);
+    }
+	
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: de.czymm.serversigns.ServerSignsPlugin
 version: ${version}
 api-version: 1.13
 authors: [CalibeR50, Exloki]
-softdepend: [Vault, NoCheatPlus, Essentials]
+softdepend: [Vault, NoCheatPlus, Essentials, PlaceholderAPI]
 load: POSTWORLD
 description: >
              ServerSigns


### PR DESCRIPTION
Added compatibility with placeholderAPI

Example:

```
/svs add <if> placeholder:%luckperms_has_permission_somePermission%=yes
/svs add <msg> OK
/svs add <endif>
```

////

```
/svs add <if> placeholder:%player_name%=Seruhio|Peter|NickName
/svs add <msg> OK
/svs add <endif>
```

