### PR TITLE
Feature/warning blocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,14 +8,18 @@
     <artifactId>ServerSigns</artifactId>
     <version>4.5.2</version>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/de/czymm/serversigns/persist/mapping/BlocksIdMapper.java
+++ b/src/main/java/de/czymm/serversigns/persist/mapping/BlocksIdMapper.java
@@ -17,6 +17,7 @@
 
 package de.czymm.serversigns.persist.mapping;
 
+import de.czymm.serversigns.ServerSignsPlugin;
 import de.czymm.serversigns.utils.MaterialConvertor;
 import de.czymm.serversigns.utils.NumberUtils;
 import org.bukkit.Material;
@@ -25,6 +26,7 @@ import org.bukkit.configuration.MemorySection;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.logging.Level;
 
 public class BlocksIdMapper implements IPersistenceMapper<EnumSet<Material>> {
     private MemorySection memorySection;
@@ -36,15 +38,25 @@ public class BlocksIdMapper implements IPersistenceMapper<EnumSet<Material>> {
 
     @Override
     public EnumSet<Material> getValue(String path) {
+        List<String> unknownMaterials = new ArrayList<>();
         List<String> blocksList = memorySection.getStringList(path);
         EnumSet<Material> blocks = EnumSet.noneOf(Material.class);
+
         for (String blockId : blocksList) {
             int val = NumberUtils.parseInt(blockId, -1);
             Material material = MaterialConvertor.getMaterialById(val);
             if (material != null) {
                 blocks.add(material);
+            } else {
+                unknownMaterials.add(blockId);
             }
         }
+
+        if (!unknownMaterials.isEmpty()) {
+            ServerSignsPlugin.log("Wrong blocks : " + String.join(", ", unknownMaterials), Level.WARNING);
+            ServerSignsPlugin.log("Please visit the wiki : https://serversigns.de/wiki/Configuration", Level.WARNING);
+        }
+
         return blocks;
     }
 

--- a/src/main/java/de/czymm/serversigns/persist/mapping/BlocksIdMapper.java
+++ b/src/main/java/de/czymm/serversigns/persist/mapping/BlocksIdMapper.java
@@ -53,7 +53,7 @@ public class BlocksIdMapper implements IPersistenceMapper<EnumSet<Material>> {
         }
 
         if (!unknownMaterials.isEmpty()) {
-            ServerSignsPlugin.log("Wrong blocks : " + String.join(", ", unknownMaterials), Level.WARNING);
+            ServerSignsPlugin.log("Unknown blocks : " + String.join(", ", unknownMaterials), Level.WARNING);
             ServerSignsPlugin.log("Please visit the wiki : https://serversigns.de/wiki/Configuration", Level.WARNING);
         }
 

--- a/src/main/java/de/czymm/serversigns/persist/mapping/BlocksMapper.java
+++ b/src/main/java/de/czymm/serversigns/persist/mapping/BlocksMapper.java
@@ -17,12 +17,14 @@
 
 package de.czymm.serversigns.persist.mapping;
 
+import de.czymm.serversigns.ServerSignsPlugin;
 import org.bukkit.Material;
 import org.bukkit.configuration.MemorySection;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.logging.Level;
 
 public class BlocksMapper implements IPersistenceMapper<EnumSet<Material>> {
     private MemorySection memorySection;
@@ -34,14 +36,24 @@ public class BlocksMapper implements IPersistenceMapper<EnumSet<Material>> {
 
     @Override
     public EnumSet<Material> getValue(String path) {
+        List<String> unknownMaterials = new ArrayList<>();
         List<String> blocksList = memorySection.getStringList(path);
         EnumSet<Material> blocks = EnumSet.noneOf(Material.class);
+
         for (String block : blocksList) {
             Material material = Material.getMaterial(block);
             if (material != null) {
                 blocks.add(material);
+            } else {
+                unknownMaterials.add(block);
             }
         }
+
+        if (!unknownMaterials.isEmpty()) {
+            ServerSignsPlugin.log("Wrong blocks : " + String.join(", ", unknownMaterials), Level.WARNING);
+            ServerSignsPlugin.log("Please visit the wiki : https://serversigns.de/wiki/Configuration", Level.WARNING);
+        }
+
         return blocks;
     }
 

--- a/src/main/java/de/czymm/serversigns/persist/mapping/BlocksMapper.java
+++ b/src/main/java/de/czymm/serversigns/persist/mapping/BlocksMapper.java
@@ -50,7 +50,7 @@ public class BlocksMapper implements IPersistenceMapper<EnumSet<Material>> {
         }
 
         if (!unknownMaterials.isEmpty()) {
-            ServerSignsPlugin.log("Wrong blocks : " + String.join(", ", unknownMaterials), Level.WARNING);
+            ServerSignsPlugin.log("Unknown blocks : " + String.join(", ", unknownMaterials), Level.WARNING);
             ServerSignsPlugin.log("Please visit the wiki : https://serversigns.de/wiki/Configuration", Level.WARNING);
         }
 


### PR DESCRIPTION
- Set source and target version for maven build to java 1.8
- Set encoding of sources to UTF-8
- Add warning to BlocksIdMapper and BlocksMapper to warn player that some config blocks doesn't exist